### PR TITLE
posts are now full screen and layout consistent with python notebook pages

### DIFF
--- a/_layouts/nosidebar.html
+++ b/_layouts/nosidebar.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+    <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <![endif]-->
+    <link rel="icon" href="{{ "/images/cropped-CE-logo-COL-graphic-512-192x192.png" | relative_url }}" sizes="192x192">
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-45778515-2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-45778515-2');
+    </script>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css" integrity="sha384-9gVQ4dYFwwWSjIDZnLEWnxCjeSWFphJiwGPXr1jddIhOegiu1FwO5qRGvFXOdJZ4" crossorigin="anonymous">
+  </head>
+  <body>
+      <nav class="navbar navbar-expand-lg navbar-light bg-light">
+        <a class="navbar-brand" href="/">Climate CMS</a>
+            <ul class="navbar-nav mr-auto">
+                {% if page.previous.url %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{page.previous.url}}">&laquo; {{page.previous.title}}</a>
+                    </li>
+                {% endif %}
+                {% if page.next.url %}
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{page.next.url}}">{{page.next.title}} &raquo;</a>
+                    </li>
+                {% endif %}
+            </ul>
+      </nav>
+      <div tabindex="-1" id="post" class="border-box-sizing">
+        <div class="container" id="post-container">
+         {{ content }}
+        </div>
+      </div>
+    <script src="{{ "/assets/js/scale.fix.js" | relative_url }}"></script>
+  </body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,0 +1,14 @@
+---
+layout: nosidebar
+---
+
+<small>{{ page.date | date: "%-d %B %Y" }}</small>
+<h1>{{ page.title }}</h1>
+
+<p class="view">by {{ page.author | default: site.author }}</p>
+
+{{content}}
+
+{% if page.tags %}
+  <small>tags: <em>{{ page.tags | join: "</em> - <em>" }}</em></small>
+{% endif %}


### PR DESCRIPTION
posts are now full screen and layout consistent with python notebook pages

Pretty hacky, but seems ok. Easy to undo by changing the default layout back to default